### PR TITLE
Fixing Mount on Build Assets Step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,7 @@ clean:
 
 .PHONY: build-static-assets
 build-static-assets:
-	 docker run \
-		-v $(shell pwd)/build:/node/build \
-		-v $(shell pwd)/src:/node/src \
-		-v $(shell pwd)/public:/node/public \
-		$(DOCKER_IMAGE):$(VERSION) yarn build
+	docker-compose run --rm $(DOCKER_IMAGE) yarn build
 
 .PHONY: push-static-assets
 push-static-assets:


### PR DESCRIPTION
## Description

<!-- A summary of changes being introduced -->

Using the `docker-compose.yaml` when building assets which have proper mounting in place when we run `make push-static-assets` in the `branch.yaml` pipeline.

**Change Log**

<!--- Walk through the files you have updated and document the major changes and reasons. --->
<!--- Each item should be numbered and explain technical details of the implementation.  --->
<!--- Pretend you are justifying each change to an engineer next to you. -->

1. Fixing the `Makefile` to use `docker-compose` when running `yarn build`

## Test Plan

N/A

<!--- Please describe in detail how to test your changes. -->

## Checklist

- [ ] Unit tests written/refactored for any new code added/changed
- [ ] Test coverage has not been reduced
- [ ] Linting requirements met
- [x] CI is passing
